### PR TITLE
Added dll export/import definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,5 +10,5 @@ target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/in
 target_link_libraries(${PROJECT_NAME} Qt::Core)
 
 add_executable(test_${PROJECT_NAME} test/test.cpp)
-target_link_libraries(test_${PROJECT_NAME} ${PROJECT_NAME})
+target_link_libraries(test_${PROJECT_NAME} Qt::Core ${PROJECT_NAME})
 

--- a/include/qssdocument.h
+++ b/include/qssdocument.h
@@ -7,7 +7,7 @@
 
 namespace qss
 {
-    class Document : public IParseable
+    class QSS_API Document : public IParseable
     {
     public:
 

--- a/include/qssexception.h
+++ b/include/qssexception.h
@@ -5,7 +5,7 @@
 
 namespace qss
 {
-    class Exception
+    class QSS_API Exception
     {
     public:
 

--- a/include/qssfragment.h
+++ b/include/qssfragment.h
@@ -6,7 +6,7 @@
 
 namespace qss
 {
-    class Fragment : public IParseable
+    class QSS_API Fragment : public IParseable
     {
     public:
 

--- a/include/qssparseable.h
+++ b/include/qssparseable.h
@@ -5,7 +5,7 @@
 
 namespace qss
 {
-    class IParseable
+    class QSS_API IParseable
     {
     public:
 

--- a/include/qsspropertyblock.h
+++ b/include/qsspropertyblock.h
@@ -6,7 +6,7 @@
 
 namespace qss
 {
-    class PropertyBlock : public IParseable
+    class QSS_API PropertyBlock : public IParseable
     {
     public:
 

--- a/include/qssselector.h
+++ b/include/qssselector.h
@@ -5,7 +5,7 @@
 
 namespace qss
 {
-    class Selector : public IParseable
+    class QSS_API Selector : public IParseable
     {
     public:
 

--- a/include/qssselectorelement.h
+++ b/include/qssselectorelement.h
@@ -6,7 +6,7 @@
 
 namespace qss
 {
-    class SelectorElement : public IParseable
+    class QSS_API SelectorElement : public IParseable
     {
     public:
 

--- a/include/qssutils.h
+++ b/include/qssutils.h
@@ -11,6 +11,21 @@
 #include <string>
 #include <type_traits>
 
+#ifdef _WIN32
+#ifdef qss_EXPORTS
+#define QSS_API __declspec(dllexport)
+#else
+#ifndef QSS_STATIC
+#define QSS_API __declspec(dllimport)
+#else
+#define QSS_API
+#endif
+#endif
+#else // _WIN32
+#define QSS_API
+#endif // _WIN32
+
+
 #define LOG(X)  { std::cout << qss::tab(2) << X << std::endl; }
 #define START() { std::cout << qss::tab(1) << "In [" __FUNCTION__ << "]" << std::endl; }
 #define END() { qss::tab(0); std::cout << qss::tab(2) << "Out [" __FUNCTION__ << "]" << std::endl; }
@@ -84,9 +99,9 @@ namespace qss
         return QString{ "\"%1\"" }.arg(input);
     }
 
-    std::ostream& operator<<(std::ostream& stream, const QString& str);
+    QSS_API std::ostream& operator<<(std::ostream& stream, const QString& str);
     
-    std::ostream& operator<<(std::ostream& stream, const QStringList& list);
+    QSS_API std::ostream& operator<<(std::ostream& stream, const QStringList& list);
 }
 
 #endif

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,6 +1,8 @@
 #include <QCoreApplication>
+#include <QString>
 
 #include "qssdocument.h"
+
 
 #define RESULTV(A, B, V) LOG(A << " should be: " << #V << " | Test pass status: " << (B == V));
 #define RESULTSTR(A, B, V) LOG(A << " should be: " << V << " | Test pass status: " << (B == V));


### PR DESCRIPTION
On windows, lib files for shared libraries isn't created if there aren't
any exported symbols and compilation fails because of this.

Added dll export/import definition, and marked classes and
global functions with them.